### PR TITLE
Slackのアドレス保存用にFirebaseを追加、判定処理を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 var express = require('express');
 
-var bodyParser = require('body-parser');
+// var bodyParser = require('body-parser');
 
 var app = express();
 
@@ -9,7 +9,7 @@ var config = require('./config');
 
 var core = require('./core')(config);
 
-app.use(bodyParser.urlencoded({ extended: false }));
+// app.use(bodyParser.urlencoded({ extended: false }));
 
 if (config['enable_slack_command']) {
   var slack = require('./plugins/slack')(core, config);

--- a/core.js
+++ b/core.js
@@ -1,22 +1,29 @@
 
 var Colu = require('colu');
+var Firebase = require('firebase');
 
 var _core = function(conf) {
   var core = {};
   var colu_private_seed = conf['colu_private_seed'];
 
-  var settings = {
-    apiKey: apiKey,
+  var colu_settings = {
+    apiKey: conf['api_key'],
     network: 'mainnet',
     privateSeed: null
   };
 
-  var colu = new Colu(settings);
-  colu.on('connect', function () {
+  var firebase_config = {
+    apiKey: conf['firebase_apiKey'],
+    authDomain: conf['firebase_authDomain'],
+    databaseURL: conf['firebase_databaseURL'],
+    storageBucket: conf['firebase_storageBucket'],
+    messagingSenderId: conf['firebase_messagingSenderId']
+  };
 
-  });
+  // 参照
+  core.firebase = Firebase.initializeApp(firebase_config);
+  core.colu = new Colu(colu_settings);
 
-  colu.init();
   return core;
 };
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "homepage": "https://github.com/ozcn/zenos-slack#readme",
   "dependencies": {
-    "colu": "^0.11.1"
+    "colu": "0.11.1",
+    "express": "4.14.1",
+    "firebase": "3.6.10"
   }
 }

--- a/plugins/slack.js
+++ b/plugins/slack.js
@@ -61,9 +61,33 @@ var _slack = function(core, conf) {
   var parseCommand = function(text) {
 
   };
-  var resolveSlackUserID = function(id, cb) {
 
+  var resolveSlackUserID = function(id, cb) {
+    // Slackユーザーが存在するかを確認
+    var slackUserRef = core.firebase.database().ref('slack_users/' + id);
+
+    return slackUserRef.on('value', function(snapshot) {
+      var slackUser = snapshot.val();
+
+      // ユーザーが存在しない場合に作成する
+      if (slackUser == null) {
+        core.colu.on('connect', function () {
+          var address = core.colu.hdwallet.getAddress();
+
+          // IDとアドレスをセット
+          slackUserRef.set({
+            "id": id,
+            "address": address
+          });
+        });
+
+        core.colu.init();
+      }
+
+      return slackUser;
+    });
   };
+
   var _slack = function(req, res, next) {
     if (req.body.command !== '/zenos') {
       return res.json(genErrorResponsePayload('unknwon command'));


### PR DESCRIPTION
## 何のためのコミットか？

Slackのユーザーとアドレス情報を紐付けるための処理です、
Slack上のユーザーのアドレス情報をFireabaseに保存する処理を追加した。

## どこを変更したのか？

resolveSlackUserIDメソッドの実行時に、
Firebase上にSlackのユーザーとアドレスを保存するようにしました。

## 注意点

ユーザーIDがなかった時に、
アドレス情報と一緒に保存する処理だけを追加した。